### PR TITLE
Theme customization and button flexibility

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2371,6 +2371,7 @@ export declare const ThemeContext: React.Context<Theme>
 export declare const ThemeProvider: React.Context<Theme>['Provider']
 export declare const ThemeConsumer: React.Context<Theme>['Consumer']
 export declare const useTheme: () => Theme
+export declare const Themer: any
 
 export interface IconProps extends BoxProps<'svg'> {
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -387,7 +387,7 @@ export interface Theme {
   avatarColors: string[]
   badgeColors: string[]
   colors: Colors
-  elevations: Elevation[]
+  elevations: string[]
   fills: Fills
   overlayBackgroundColor: string
   palette: Palette
@@ -395,11 +395,7 @@ export interface Theme {
   spinnerColor: string
   typography: Typography
   getIconColor(color: string): string
-  getAvatarProps(args: {
-    isSolid?: boolean
-    color: string
-    hashValue?: string
-  }): { color: string; backgroundColor: string }
+  getAvatarProps(args: any): any
 }
 
 export const defaultTheme: Theme
@@ -539,6 +535,12 @@ export interface ButtonOwnProps extends TextOwnProps {
    * This also disables the button.
    */
   isLoading?: boolean
+
+  /**
+   * To support creation of button with tags like span or a
+  */
+  elementType?: string,
+
   /**
    * Forcefully set the active state of a button.
    * Useful in conjuction with a Popover.

--- a/src/buttons/src/Button.js
+++ b/src/buttons/src/Button.js
@@ -49,6 +49,7 @@ const Button = memo(
       disabled,
       appearance = 'default',
       isLoading,
+      elementType,
 
       // Paddings
       paddingRight,
@@ -75,7 +76,7 @@ const Button = memo(
 
     return (
       <Text
-        is="button"
+        is={elementType || 'button'}
         ref={ref}
         className={cx(themedClassName, className)}
         borderTopRightRadius={borderRadius}
@@ -155,6 +156,11 @@ Button.propTypes = {
    * This also disables the button.
    */
   isLoading: PropTypes.bool,
+
+  /**
+   * To support creation of button with tags like span or a
+   */
+  elementType: PropTypes.string,
 
   /**
    * Forcefully set the active state of a button.

--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,7 @@ export {
   useTheme,
   defaultTheme
 } from './theme'
+export { Themer } from './themer'
 export { Textarea, TextareaField } from './textarea'
 export { toaster } from './toaster'
 export { Tooltip } from './tooltip'


### PR DESCRIPTION
This PR improves flexibility of custom themes
Currently [theme support ](https://github.com/segmentio/evergreen#theming-support) on evergreen is not very flexible, I have done some monkey-patching to improve flexibility of themes

Also, added a small feature to render button as span, to use it for File Upload buttons which don't have a direct onClick listener.